### PR TITLE
Improve `STRUCTS_REGEX`

### DIFF
--- a/C2Py/C2PyEngine.py
+++ b/C2Py/C2PyEngine.py
@@ -67,7 +67,7 @@ FORMAT_MAP = {
 # Important regular expressions to parse C structs to groups of fields (in strings) and from them create formats
 # Not broken down to multiple lines for readability
 STRUCTS_REGEX = re.compile(
-    r"(typedef\s+)?(?P<PACKED>\w+)?\s*(?P<TYPE>union|struct|enum)\s+(?P<NAME2>\w+)\s*\{(?P<FIELDS>.*?(?:\{.*?\}.*?)*?)\}(?P<NAME>[^;]*);",
+    r"(typedef\s+)?(?P<PACKED>\w+)?\s*(?P<TYPE>union|struct|enum)\s+(?P<NAME2>\w*)\s*\{(?P<FIELDS>.*?(?:\{.*?\}.*?)*?)\}\s*(?P<NAME>(?:[^;\s]|\s*,\s*)*)\s*;",
     re.S)
 ENUM_TYPES_REGEX = re.compile(r"(?P<NAME>\w+)\s*(=(?P<DEF>.[^,]*)|,|$)", re.S)
 BASIC_TYPES_REGEX = re.compile(

--- a/C2Py/tests/Header.h
+++ b/C2Py/tests/Header.h
@@ -127,4 +127,28 @@ typedef struct Test12
 	char omittedSize[0];
 } *Test12;
 
+typedef struct {
+    int member;
+} Test15;
+
+typedef struct {
+    int member;
+} Test16 ;
+
+typedef struct Test17 {
+    int member;
+} Test17;
+
+typedef struct Test18{
+    int member;
+} Test18 ;
+
+struct Test19 {
+    int member;
+} ;
+
+struct Test20 {
+    int member;
+};
+
 #endif

--- a/C2Py/tests/Source.c
+++ b/C2Py/tests/Source.c
@@ -37,6 +37,14 @@ int main()
 	//Test11 hello = { "Hello, world!", { "ran", "dom", " st", "rin", "g.." } };
 	Test11 hello;
 	Test12 hacker = malloc(sizeof(struct Test12) + sizeof(char) * N);
+
+	Test15 whitespace1 = {0};
+	Test16 whitespace2 = {0};
+	Test17 whitespace3 = {0};
+	Test18 whitespace4 = {0};
+	struct Test19 whitespace5 = {0};
+	struct Test20 whitespace6 = {0};
+
 	int i;
 	FILE *fileWriter = NULL;
 
@@ -61,6 +69,14 @@ int main()
 	fwrite(&test10, sizeof(union Test10), 1, fileWriter);
 	fwrite(&hello, sizeof(Test11), 1, fileWriter);
 	fwrite(hacker, sizeof(struct Test12), 1, fileWriter);
+
+	fwrite(&whitespace1, sizeof(Test15), 1, fileWriter);
+	fwrite(&whitespace2, sizeof(Test16), 1, fileWriter);
+	fwrite(&whitespace3, sizeof(Test17), 1, fileWriter);
+	fwrite(&whitespace4, sizeof(Test18), 1, fileWriter);
+	fwrite(&whitespace5, sizeof(struct Test19), 1, fileWriter);
+	fwrite(&whitespace6, sizeof(struct Test20), 1, fileWriter);
+
 	fclose(fileWriter);
 
 	// For debug purposes

--- a/C2Py/tests/test.py
+++ b/C2Py/tests/test.py
@@ -633,6 +633,46 @@ class C2PyTest(unittest.TestCase):
 
         self.assertEqual(size_of, ctypes.sizeof(to_compare))
 
+    def impl_test_whitespace(self, struct_name):
+        global MEMORY_OFFSET
+
+        test_struct = self.c2py_handler.convert(struct_name, offset=MEMORY_OFFSET)
+        size_of = ctypes.sizeof(test_struct)
+        MEMORY_OFFSET += size_of
+        print(test_struct)
+        print("Size of struct: " + str(size_of) + "\n")
+
+        to_compare_class = _generate_new_struct()
+        to_compare_class._fields_ = [("member", ctypes.c_int)]
+        to_compare = to_compare_class()
+        to_compare.member == 0
+
+        try:
+            self.assertEqual(test_struct.member, to_compare.member)
+        except AttributeError as ex:
+            # Fail the test
+            self.assertFalse(True, ex)
+
+        self.assertEqual(size_of, ctypes.sizeof(to_compare))
+
+    def test15(self):
+        self.impl_test_whitespace("Test15")
+
+    def test16(self):
+        self.impl_test_whitespace("Test16")
+
+    def test17(self):
+        self.impl_test_whitespace("Test17")
+
+    def test18(self):
+        self.impl_test_whitespace("Test18")
+
+    def test19(self):
+        self.impl_test_whitespace("Test19")
+
+    def test20(self):
+        self.impl_test_whitespace("Test20")
+
 
 def run_test():
     """
@@ -667,6 +707,14 @@ def run_test():
 
     # Default runtime buffer handler tests
     suite.addTest(C2PyTest('test14', runtime_buffer_handler))
+
+    # Struct with whitespace parsing test
+    suite.addTest(C2PyTest('test15', binary_file_handler))
+    suite.addTest(C2PyTest('test16', binary_file_handler))
+    suite.addTest(C2PyTest('test17', binary_file_handler))
+    suite.addTest(C2PyTest('test18', binary_file_handler))
+    suite.addTest(C2PyTest('test19', binary_file_handler))
+    suite.addTest(C2PyTest('test20', binary_file_handler))
 
     unittest.TextTestRunner().run(suite)
 


### PR DESCRIPTION
Hi,
I figured while using C2Py that the regex for finding structs was slightly unforgiving (I haven't looked at the others, maybe there's similar issues)

-----------

Consider the following C code:
```c
typedef struct {
    int member;
} StructName;

typedef struct {
    int member;
} StructName ;

typedef struct StructName {
    int member;
} StructName;

typedef struct StructName{
    int member;
} StructName ;

struct StructName {
    int member;
} ;

struct StructName {
    int member;
};
```

---------------

With the current regex https://regex101.com/r/CnFMdD/1 ,
- The first two cases don't match
- In the third case the `NAME` group is matched as `" StructName"`, I think the whitespace throws up C2Py somewhere
- Fourth case: same as four, whitespace also after the struct name
- Fifth case: the `NAME` group is matched as `" "` (just whitespace), again makes C2Py or the lookup not work
- Sixth case: OK

-------------

With the proposed regex https://regex101.com/r/5cph0W/1 ,
all cases match and the groups don't include whitespace